### PR TITLE
change "github.com/golang" to "golang.org/x"

### DIFF
--- a/examples/websockets/main.go
+++ b/examples/websockets/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/golang/net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 func main() {

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
-github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/davecheney/benchall v0.0.0-20171007110800-9b613171f3a2 h1:Xef+MzPasBtZvN9shhcDlFwsMOR9N+CYM4Hnx0f2pE8=
-github.com/davecheney/benchall v0.0.0-20171007110800-9b613171f3a2/go.mod h1:huACmd6/Tc+6VkO2sSVZ1LXT16XUB7iNAxNODatkuL8=
 github.com/golang/net v0.0.0-20190213061140-3a22650c66bd h1:csDe9bk66ilRldyDxPBPKfQJwPd11g7Fgj6/fW5+Xxg=
 github.com/golang/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:98y8FxUyMjTdJ5eOj/8vzuiVO14/dkJ98NYhEPG8QGY=
-github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd h1:HuTn7WObtcDo9uEEU7rEqL0jYthdXAmZ6PP+meazmaU=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/golang/net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 func tcpListen() {

--- a/socket.go
+++ b/socket.go
@@ -3,7 +3,7 @@ package main
 import (
 	"io"
 
-	"github.com/golang/net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 type socket struct {


### PR DESCRIPTION
there is issue about import from **github.com/golang/net/websocket** I don't know why.
but as you can find here https://github.com/golang/net it talks about [mirror] at https://godoc.org/golang.org/x/net. when in change the import, it worked.

also there is an issue in **messages duplication**  if you allow me i will try to fix.